### PR TITLE
Поиск необходимых библиотек при помощи pkg-config в скрипте сборки.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,15 @@
 cmake_minimum_required(VERSION 3.5)
+include(FindPkgConfig)
 project(library)
 
 set(CMAKE_CXX_STANDARD 17)
 
+find_package(PkgConfig REQUIRED)
+pkg_search_module(JSONCPP REQUIRED jsoncpp)
+pkg_search_module(PUGIXML REQUIRED pugixml)
+
 set(SOURCE_FILES Library.cpp)
 add_executable(library ${SOURCE_FILES})
+target_include_directories(library PRIVATE ${JSONCPP_INCLUDE_DIRS})
+target_include_directories(library PRIVATE ${PUGIXML_INCLUDE_DIRS})
+target_link_libraries(library ${JSONCPP_LDFLAGS})

--- a/Library.cpp
+++ b/Library.cpp
@@ -8,8 +8,8 @@
 #include<fstream>
 #include<sstream>
 #include<functional>
-#include"jsoncpp/json/json.h"
-#include"pugixml.hpp"
+#include<jsoncpp/json/json.h>
+#include<pugixml.hpp>
 
 
 


### PR DESCRIPTION
Это даже не замечание, это просто мелочь для удобства, без которой, с другой стороны, в больших проектах не обойтись.
Лично у меня не было pugixml и jsoncpp в системе, эти изменения позволят во-первых: понять что у тебя чего-то не хватает прямо когда ты открываешь проект и во-вторых искать библиотеки расположенные не только в стандартных путях.
Если будет интересно, то почитать о том как этим пользоваться можно [тут](https://cmake.org/cmake/help/v3.0/module/FindPkgConfig.html) и [тут](https://cmake.org/cmake/help/v3.8/command/find_package.html)